### PR TITLE
Use device name for ha display, starts cover immediately

### DIFF
--- a/adapters/alarm.coffee
+++ b/adapters/alarm.coffee
@@ -15,7 +15,7 @@ module.exports = (env) ->
       @discoveryId = discovery_prefix
       @hassDeviceId = device_prefix + "_" + device.id
       @device_prefix = device_prefix
-      @hassDeviceFriendlyName = device_prefix + ": " + device.id
+      @hassDeviceFriendlyName = device.name
 
 
       @code = @device._pin ? "0000"

--- a/adapters/binarysensor.coffee
+++ b/adapters/binarysensor.coffee
@@ -14,7 +14,7 @@ module.exports = (env) ->
 
       @discoveryId = discovery_prefix
       @hassDeviceId = device_prefix + "_" + device.id
-      @hassDeviceFriendlyName = device_prefix + ": " + device.id
+      @hassDeviceFriendlyName = device.name
       @discoveryId = discovery_prefix
       @hasContactSensor = false
       @hasPresenceSensor = false

--- a/adapters/buttons.coffee
+++ b/adapters/buttons.coffee
@@ -156,7 +156,7 @@ module.exports = (env) ->
       @pimaticId = discovery_prefix
       @discoveryId = discovery_prefix
       @hassDeviceId = device_prefix + "_" + @device.id + "_" + @button.id
-      @hassDeviceFriendlyName = device_prefix + ": " + device.id + "." + @button.id
+      @hassDeviceFriendlyName = device.name + "." + @button.id
       @_getVar = "get" + (@button.id).charAt(0).toUpperCase() + (@button.id).slice(1)
 
     handleMessage: (buttonId) =>

--- a/adapters/cover.coffee
+++ b/adapters/cover.coffee
@@ -147,20 +147,20 @@ module.exports = (env) ->
       _value = packet.payload
       env.logger.debug "Cover payload " + _value + ", @_coverPosition " + @_coverPosition
       if (String _value) is "CLOSE" and @_coverPosition isnt @cover.position.closed
+        @device.moveToPosition("down")
         @state.position = "closing"
         @publishState()
         @rollingTimer = setTimeout(()=>
-          @device.moveToPosition("down")
           @state.position = "closed"
           @_coverPosition = @cover.position.closed
           @publishState()
         , @rollingtime)
 
       else if (String _value) is "OPEN" and @_coverPosition isnt @cover.position.open
+        @device.moveToPosition("up")
         @state.position = "opening"
         @publishState()
         @rollingTimer = setTimeout(()=>
-          @device.moveToPosition("up")
           @state.position = "open"
           @_coverPosition = @cover.position.open
           @publishState()
@@ -180,10 +180,10 @@ module.exports = (env) ->
 
       else
         env.logger.debug "Message for Cover not found, resetting to closed cover"
+        @device.moveToPosition("down")
         @state.position = "closing"
         @publishState()
         @rollingTimer = setTimeout(()=>
-          @device.moveToPosition("down")
           @state.position = "closed"
           @_coverPosition = @cover.position.closed
           @publishState()

--- a/adapters/cover.coffee
+++ b/adapters/cover.coffee
@@ -15,7 +15,7 @@ module.exports = (env) ->
       @discoveryId = discovery_prefix
       @hassDeviceId = device_prefix + "_" + device.id
       @device_prefix = device_prefix
-      @hassDeviceFriendlyName = device_prefix + ": " + device.id
+      @hassDeviceFriendlyName = device.name
 
       @publishDiscovery()
 

--- a/adapters/light.coffee
+++ b/adapters/light.coffee
@@ -13,7 +13,7 @@ module.exports = (env) ->
       @client = client
       @discoveryId = discovery_prefix
       @hassDeviceId = device_prefix + "_" + device.id
-      @hassDeviceFriendlyName = device_prefix + ": " + device.id
+      @hassDeviceFriendlyName = device.name
 
       @publishDiscovery()
 

--- a/adapters/rgblight.coffee
+++ b/adapters/rgblight.coffee
@@ -14,7 +14,7 @@ module.exports = (env) ->
       @client = client
       @discoveryId = discovery_prefix
       @hassDeviceId = device_prefix + "_" + device.id
-      @hassDeviceFriendlyName = device_prefix + ": " + device.id
+      @hassDeviceFriendlyName = device.name
 
       @publishDiscovery()
 

--- a/adapters/sensor.coffee
+++ b/adapters/sensor.coffee
@@ -110,7 +110,7 @@ module.exports = (env) ->
       @discoveryId = discovery_prefix
       @device_prefix = device_prefix
       @hassDeviceId = device_prefix+ "_" + device.id + "_" + @attributeName
-      @hassDeviceFriendlyName = device_prefix + ": " + device.id + "." + @attributeName
+      @hassDeviceFriendlyName = device.name + "." + @attributeName
       @_getVar = "get" + (@attributeName).charAt(0).toUpperCase() + (@attributeName).slice(1)
       env.logger.debug "@unit: " + @unit
 

--- a/adapters/switch.coffee
+++ b/adapters/switch.coffee
@@ -16,7 +16,7 @@ module.exports = (env) ->
       @discoveryId = discovery_prefix
       @hassDeviceId = device_prefix + "_" + device.id
       @device_prefix = device_prefix
-      @hassDeviceFriendlyName = device_prefix + ": " + device.id
+      @hassDeviceFriendlyName = device.name
 
 
       @stateHandler = (state) =>

--- a/adapters/thermostat.coffee
+++ b/adapters/thermostat.coffee
@@ -16,7 +16,7 @@ module.exports = (env) ->
       @discovery_prefix = discovery_prefix
       @discoveryId = discovery_prefix
       @hassDeviceId = device_prefix + "_" + device.id
-      @hassDeviceFriendlyName = device_prefix + ": " + device.id
+      @hassDeviceFriendlyName = device.name
 
       # HASS settings
       @temperatureSetpointItem = "temperatureSetpoint"

--- a/adapters/variables.coffee
+++ b/adapters/variables.coffee
@@ -112,7 +112,7 @@ module.exports = (env) ->
       @pimaticId = discovery_prefix
       @discoveryId = discovery_prefix
       @hassDeviceId = device_prefix + "_" + device.id + "_" + @variable.name
-      @hassDeviceFriendlyName = device_prefix + ": " + device.id + "." + @variable.name
+      @hassDeviceFriendlyName = device.name + "." + @variable.name
       @_getVar = "get" + (@variable.name).charAt(0).toUpperCase() + (@variable.name).slice(1)
       env.logger.debug "Init variable Manager " + @id
 


### PR DESCRIPTION
This PR changes the display name of the device in Home Assistant. Instead of showing the device id, it uses the device name, which is more readable. 

This PR also fixes #2. 